### PR TITLE
Close job details panel on become

### DIFF
--- a/lua/pixelf4/elements/partials/cl_selected_job.lua
+++ b/lua/pixelf4/elements/partials/cl_selected_job.lua
@@ -173,6 +173,7 @@ function PANEL:Init()
             RunConsoleCommand("darkrp", self:GetCommand())
         end
 
+        self:Close()
         PIXEL.F4.ToggleMenu()
     end
 


### PR DESCRIPTION
It is annoying when it stays up after selecting a job